### PR TITLE
`setup.py install` fails on some Ubuntus.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 from distutils import sysconfig
+import sys
 import re
 #from setuptools.dist import Distribution
 
@@ -20,7 +21,7 @@ except Exception as exc:
 #class PureDistribution(Distribution):
 #    def is_pure(self):
 #        return True
-    
+
 setup(
     name = 'coverage_pth',
     version = '0.0.1',

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,18 @@ import re
 #from setuptools.dist import Distribution
 
 site_packages_path = sysconfig.get_python_lib()
-sprem = re.match(
-    r'.*(lib[\\/](python\d\.\d[\\/])?site-packages)', site_packages_path, re.I)
-rel_site_packages = sprem.group(1)
+try:
+    sprem = re.match(
+        r'.*(lib[\\/](python\d(\.\d)*[\\/])?site-packages)', site_packages_path, re.I)
+    if sprem is None:
+        sprem = re.match(
+            r'.*(lib[\\/](python\d(\.\d)*[\\/])?dist-packages)', site_packages_path, re.I)
+    rel_site_packages = sprem.group(1)
+except Exception as exc:
+    print("I'm having trouble finding your site-packages directory.  Is it where you expect?")
+    print("sysconfig.get_python_lib() returns '{}'".format(site_packages_path))
+    print("Exception was: {}".format(exc))
+    sys.exit(-1)
 
 #class PureDistribution(Distribution):
 #    def is_pure(self):


### PR DESCRIPTION
This PR expands the locations that setup.py will look for `site-packages`.  Some Ubuntus (and Debians?) locate site-packages in /usr/lib/python2.7/dist-packages.  Also some distros don't have /usr/lib/python in the form of /usr/lib/pythonX.Y, but just /usr/lib/pythonX.

I also added a little bit of guidance as to why setup.py might not be able to find site-packages.
